### PR TITLE
Fix bug when empty http proxy env var

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,8 +37,12 @@ app.include_router(example_router)
 
 
 def main() -> None:  # pragma: no cover
-    os.environ["HTTP_PROXY"] = str(config.http_proxy)
-    os.environ["HTTPS_PROXY"] = str(config.http_proxy)
+    if config.http_proxy:
+        os.environ["HTTP_PROXY"] = str(config.http_proxy)
+        os.environ["HTTPS_PROXY"] = str(config.http_proxy)
+    else:
+        os.environ.pop("HTTP_PROXY", None)
+        os.environ.pop("HTTPS_PROXY", None)
 
     uvicorn.run(
         "app.main:app",

--- a/app/test_main.py
+++ b/app/test_main.py
@@ -71,5 +71,5 @@ def test_main_no_proxy_in_config(mocker, monkeypatch):
 
     main_mod.main()
 
-    assert os.environ.get("HTTP_PROXY") == "None"
-    assert os.environ.get("HTTPS_PROXY") == "None"
+    assert os.environ.get("HTTP_PROXY") is None
+    assert os.environ.get("HTTPS_PROXY") is None


### PR DESCRIPTION
Conditionally sets HTTP and HTTPS proxy environment variables if a proxy is configured. If no proxy is specified in the configuration, it explicitly removes these environment variables.

This prevents the application from attempting to use a potentially invalid or non-existent proxy when one is not intended to be used.